### PR TITLE
chore(github): implement multi-platform docker images

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,7 +13,8 @@ env:
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
-
+  # Target platforms
+  PLATFORMS: linux/amd64,linux/arm/v7,linux/arm64
 
 jobs:
   build:
@@ -63,6 +64,7 @@ jobs:
         uses: docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94
         with:
           context: .
+          platforms: ${{ env.PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Hi @riesinger,

Thanks for providing plausible exporter for prometheus! 🚀

I would love to use this in my homelab K8s cluster but currently your repository does not provide arm64 images.

It would be great if you are willing to accept my pull request which adds multi-platform image builds using the `platforms` input of the `docker/build-push-action`. 😊

BR, Pascal