### PR TITLE
docs(readme): add short reference section to community helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ make # or "make static"
 
 For configuration see [this section](#configuration).
 
+### Kubernetes / Helm
+
+If you want to run this exporter inside a Kubernetes cluster you can use this [community contributed Helm chart](https://charts.pascaliske.dev/charts/plausible-exporter/) by [@pascaliske](https://github.com/pascaliske).
+
+For configuration see [this section](#configuration).
+
 ### Configuration
 
 The exporter can be configured via a `config.yaml` file placed in `/etc/plausible-exporter` or via environment variables.


### PR DESCRIPTION
Hi @riesinger,

It's me again, hope you're doing well.

I built a Helm chart for your exporter to run inside my K8s cluster:

- https://charts.pascaliske.dev/charts/plausible-exporter/
- https://github.com/pascaliske/helm-charts

I mentioned you / your source repository inside the README of course!

Are you willing to mention it inside your repository? It would be an honor for me!
But feel free to close this PR if you don't want to mention it! 🙂

BR, Pascal