### PR TITLE
feat: add bearer auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ The exporter can be configured via a `config.yaml` file placed in `/etc/plausibl
 When put into a config file, the variable names are `snake_cased`, when set via the environment, the variables must be `UPPER_SNAKE_CASED`.
 All options can be set in the config file or environment variables, with environment variables taking precedence.
 
-| Option               | Required | Description                                                      | Default        |
-| -------------------- | -------- | ---------------------------------------------------------------- | -------------- |
-| `plausible_host`     | ✅       | The hostname and protocol of your plausible server               | -              |
-| `plausible_site_ids` | ✅       | The IDs of the sites you want to fetch from plausible, as a list | -              |
-| `plausible_token`    | ✅       | A valid API token for your plausible server                      | -              |
-| `listen_address`     | ❌       | Which host and port to listen to                                 | `0.0.0.0:8080` |
+| Option               | Required | Description                                                            | Default        |
+| -------------------- | -------- | ---------------------------------------------------------------------- | -------------- |
+| `plausible_host`     | ✅       | The hostname and protocol of your plausible server                     | -              |
+| `plausible_site_ids` | ✅       | The IDs of the sites you want to fetch from plausible, as a list       | -              |
+| `plausible_token`    | ✅       | A valid API token for your plausible server                            | -              |
+| `listen_address`     | ❌       | Which host and port to listen to                                       | `0.0.0.0:8080` |
+| `bearer_auth_token`  | ❌       | Bearer token to authorize metrics route through `Authorization` header | -              |
 
 > **Note:** Config options that are lists must be comma-separated when passed as an environment variable, e.g. `PLAUSIBLE_SITE_IDS=riesinger.dev,nononsense.cooking`
 
@@ -75,6 +76,11 @@ In case you've configured multiple sites to be scraped, you can differentiate be
 
 You can use the exported metrics just like you'd use any other metric scraped by Prometheus.
 The `examples` folder contains a small [demo dashboard](./examples/grafana-dashboard.json). You can use this as a starting point for integrating the metrics into your own dashboards.
+
+#### Authorization
+
+If you want to restrict access to the metrics endpoint, you can set the `bearer_auth_token` (`BEARER_AUTH_TOKEN` environment variable) option.
+This will require the client to send a `Authorization: Bearer <token>` header with the request.
 
 ## License
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -9,10 +9,11 @@ import (
 )
 
 var (
-	listenAddress string
-	plausibleHost *url.URL
-	token         string
-	siteIDs       []string
+	listenAddress   string
+	bearerAuthToken string
+	plausibleHost   *url.URL
+	token           string
+	siteIDs         []string
 )
 
 func readConfig() error {
@@ -49,6 +50,8 @@ func readConfig() error {
 	if len(siteIDs) == 0 {
 		return fmt.Errorf("config: no plausible site IDs provided")
 	}
+
+	bearerAuthToken = viper.GetString("bearer_auth_token")
 
 	return nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,6 +57,10 @@ func main() {
 	}()
 
 	srv := server.New()
+	if bearerAuthToken != "" {
+		srv.SetBearerAuthToken(bearerAuthToken)
+	}
+
 	go func() {
 		if err := srv.ListenAndServe(listenAddress); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("server: %v\n", err)

--- a/server/auth.go
+++ b/server/auth.go
@@ -1,0 +1,24 @@
+package server
+
+import (
+	"net/http"
+)
+
+func BearerAuthMiddleware(next http.Handler, token string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		headerValue := r.Header.Get("Authorization")
+		if headerValue == "" {
+			http.Error(w, "Authorization header is required", http.StatusUnauthorized)
+			return
+		}
+
+		expectedToken := "Bearer " + token
+		if headerValue != expectedToken {
+			http.Error(w, "Invalid token", http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -1,0 +1,65 @@
+package server_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/riesinger/plausible-exporter/server"
+)
+
+func TestValidToken(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	testToken := "secret-token"
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	rr := httptest.NewRecorder()
+
+	handlerWithMiddleware := server.BearerAuthMiddleware(handler, testToken)
+	handlerWithMiddleware.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("Handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+}
+
+func TestInvalidToken(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("Handler should not be called with an invalid token")
+	})
+
+	testToken := "secret-token"
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	rr := httptest.NewRecorder()
+
+	handlerWithMiddleware := server.BearerAuthMiddleware(handler, testToken)
+	handlerWithMiddleware.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusUnauthorized {
+		t.Errorf("Handler returned wrong status code: got %v want %v", status, http.StatusUnauthorized)
+	}
+}
+
+func TestMissingToken(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("Handler should not be called without a token")
+	})
+
+	testToken := "secret-token"
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+
+	handlerWithMiddleware := server.BearerAuthMiddleware(handler, testToken)
+	handlerWithMiddleware.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusUnauthorized {
+		t.Errorf("Handler returned wrong status code: got %v want %v", status, http.StatusUnauthorized)
+	}
+}


### PR DESCRIPTION
Hi!

This PR adds basic authentication functionality for the metrics endpoint using bearer tokens.

- Added `bearer_auth_token` / `BEARER_AUTH_TOKEN` as an optional parameter to configuration
- Added auth middleware file `./server/auth.go`
- Added 3 basic test cases to `./server/auth_test.go`
- Adapted README and added further instructions

I hope this is good enough, if not please let me know what I can fix :)

Cheers,
Jonas
